### PR TITLE
CLOUD-13329: loosen google requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.0, <6.0.0 |
+| Name | Version        |
+|------|----------------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0       |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.0, <7.0.0 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 5.0, <6.0.0 |
+| Name | Version        |
+|------|----------------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 5.0, <7.0.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0, <6.0.0"
+      version = ">= 5.0, <7.0.0"
     }
   }
 }


### PR DESCRIPTION
I need to upgrade the SQL instances for staples (one at a time).
And the cloud sql module it is using doesn't let you specify the version (hardcoded to PG 12).
The upgraded module requires google > 6
This particular module requires google <= 6 so loosening to < 7